### PR TITLE
Eliminación de duplicados

### DIFF
--- a/notebooks/TP2.ipynb
+++ b/notebooks/TP2.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "!pip3 install tensorflow\n",
     "!pip3 install tensorflow_hub\n",
-    "!pip install tqdm>=4.46.0\n"
+    "!pip install \"tqdm>=4.46.0\"\n"
    ]
   },
   {
@@ -476,6 +476,47 @@
     "\n",
     "test_df2=tweets_test.copy()\n",
     "test_df2['text'] = test_df2['text'].apply(lambda x : pre_process_text(x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Eliminación de duplicados en train"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Eliminamos filas duplicadas en la columna texto (despues de normalizarlo) que tengan un target diferente para evitar inconsistencias"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "duplicated_rows_train = train_df2[train_df2.duplicated(['text'],keep=False)]\n",
+    "# de las duplicadas reviso cuales tienen target diferente\n",
+    "duplicated_groups = duplicated_rows_train.groupby('text', as_index=False).agg({'target':['sum',\"count\"]})\n",
+    "same_text_diff_target = duplicated_groups[(duplicated_groups['target']['sum'] != 0) & (duplicated_groups['target']['sum'] != duplicated_groups['target']['count'])]['text']\n",
+    "same_text_train_ids = duplicated_rows_train[duplicated_rows_train['text'].isin(same_text_diff_target)]['id']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sacamos del train set los ids duplicados\n",
+    "train_df2 = train_df2.drop(train_df2[train_df2.id.isin(same_text_train_ids)].index)\n",
+    "# y del dataset original para evitar errores si se usa el target de ese set\n",
+    "tweets_train = tweets_train.drop(tweets_train[tweets_train.id.isin(same_text_train_ids)].index)\n",
+    "# Se eliminan unas 318 filas\n",
+    "tweets_train.shape "
    ]
   },
   {


### PR DESCRIPTION
Luego de la normalización del texto, elimino aquellas filas con igual texto y diferente target

@jagomez967 lo probé en tu branch que tiene el ultimo algoritmo y mejoró un cachin el score (quedó subido el submission)
Algo importante es que cuando haces los concat tuve que cambiar una parte y hacerla así:
`train_use_tf2_s = pd.concat([train_use_tf2_k.reset_index(drop=True), train_df2['sentiment_score'].reset_index(drop=True)], axis=1, sort=False)`

Usando los `reset_index` ...te aviso por acá porque no está subido a master eso aún asi (osea esa parte de tu código con el GradientBoost)